### PR TITLE
Changed orchestrator filter episode query

### DIFF
--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -89,7 +89,9 @@ def filter_episode(
             episodes = (
                 session.query(Episode)
                 .filter(
-                    Episode.podcast.ilike(podcast), Episode.episode_id.in_(episodes_id)
+                    Episode.podcast.ilike(podcast),
+                    Episode.episode_id.in_(episodes_id),
+                    Episode.processing_stage != ProcessingStage.EMBEDDED,
                 )
                 .all()
             )


### PR DESCRIPTION
Changed fetch_db_episode to quicker querry #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Episode selection now uses backend-backed queries for more reliable, case-insensitive filtering by podcast and episode IDs, and orders results by publish date.
  * A default limit of 5 episodes applies when not specified, ensuring predictable result sizes.

* **Bug Fixes**
  * Removed local stage tracking so processing consistently picks the correct episodes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->